### PR TITLE
Add compatibility for not specifying density

### DIFF
--- a/xrayweb/templates/transmission_sample.html
+++ b/xrayweb/templates/transmission_sample.html
@@ -77,10 +77,12 @@
             <tr><td><br></td></tr>
             <tr>
                 <td></td>
-                <td></td>
+                <td>
+                    <input type="checkbox" id="getpythonscript" name="getpythonscript" {{ "checked" if request.form['getpythonscript'] }}>
+                    <label for="getpythonscript">get python script</label>
+                </td>
                 <td><input type="submit" value="Submit"></td>
             </tr>
-
 
         </table>
 

--- a/xrayweb/templates/transmission_sample.html
+++ b/xrayweb/templates/transmission_sample.html
@@ -34,7 +34,7 @@
                     <input style="width: 180px;" type="text" id="area" 
                     name="area" value="{{ request.form['area'] if request.form['area'] else 1 }}">
                 </td>
-                <td><label for="density">Density (g/cm^3):</label></td>
+                <td><label for="density">Density (g/cm^3) [optional]:</label></td>
                 <td>
                     <input style="width: 180px;" type="text" id="density" 
                     name="density" value="{{ request.form['density'] }}">

--- a/xrayweb/templates/transmission_sample.html
+++ b/xrayweb/templates/transmission_sample.html
@@ -37,7 +37,7 @@
                 <td><label for="density">Density (g/cm^3):</label></td>
                 <td>
                     <input style="width: 180px;" type="text" id="density" 
-                    name="density" value="{{ request.form['density'] if request.form['density'] else 1 }}">
+                    name="density" value="{{ request.form['density'] }}">
                 </td>
             </tr>
             <tr><td><br></td></tr>

--- a/xrayweb/webapp.py
+++ b/xrayweb/webapp.py
@@ -1140,5 +1140,31 @@ def transmission_sample(sample=None, energy=None, absorp_total=None, area=None, 
         steps = [f'{el:s}:{step:.3f}' for el, step in s.absorbance_steps.items()]
         result['Absorbance steps'] = ', '.join(steps)
 
-    return render_template('transmission_sample.html', materials_dict=materials_dict,
-                           result=result)
+        if not request.form.get('getpythonscript'):
+            return render_template('transmission_sample.html', materials_dict=materials_dict,
+                                result=result)
+        else:
+            if not density:
+                density = 'None'
+            script = """{header:s}
+
+# XAFS transmission mode sample calculation
+# inputs from web form
+sample = {sample}
+energy = {energy}
+absorp_total = {absorp_total}
+area = {area}
+density = {density}
+frac_type = '{frac_type:s}'
+
+samp = xraydb.transmission_sample(sample=sample, energy=energy, absorp_total=absorp_total,
+                                       area=area, density=density, frac_type=frac_type)
+
+print(samp)
+""".format(header=PY_TOP, sample=sample, energy=energy, 
+absorp_total=absorp_total, area=area, density=density, frac_type=frac_type)
+            return Response(script, mimetype='text/plain')
+
+    else:
+        return render_template('transmission_sample.html', materials_dict=materials_dict,
+                                result=result)

--- a/xrayweb/webapp.py
+++ b/xrayweb/webapp.py
@@ -1137,5 +1137,8 @@ def transmission_sample(sample=None, energy=None, absorp_total=None, area=None, 
         masses = [f'{el:s}:{mass:.3f}' for el, mass in s.mass_components_mg.items()]
         result['Element Masses (mg)'] = ', '.join(masses)
 
+        steps = [f'{el:s}:{step:.3f}' for el, step in s.absorbance_steps.items()]
+        result['Absorbance steps'] = ', '.join(steps)
+
     return render_template('transmission_sample.html', materials_dict=materials_dict,
                            result=result)

--- a/xrayweb/webapp.py
+++ b/xrayweb/webapp.py
@@ -1114,10 +1114,8 @@ def transmission_sample(sample=None, energy=None, absorp_total=None, area=None, 
         energy = float(request.form.get('energy'))
         absorp_total = float(request.form.get('absorp_total'))
         area = float(request.form.get('area'))
-        density = request.form.get('density', '')
-        if not density:
-            density = None
-        else:
+        density = request.form.get('density', None)
+        if density:
             density = float(density)
 
         frac_type = request.form.get('frac_type')
@@ -1129,8 +1127,8 @@ def transmission_sample(sample=None, energy=None, absorp_total=None, area=None, 
         result['Density (gr/cm^3)'] = 'None' if not density else f'{s.density:.2f}'
         result['Area (cm^2)'] = f'{s.area_cm2:.2f}'
         result['Total Absorption'] = f'{s.absorp_total:.2f}'
-        result['Thickness (\u03bCm)'] = 'None' if not s.thickness_mm else f'{s.thickness_mm*1000.0:.2f}'
-        result['Absorption length (\u03bCm)'] = 'None' if not s.absorption_length_um else f'{s.absorption_length_um:.2f}'
+        result['Thickness (\u03bCm)'] = 'Requires Density' if not s.thickness_mm else f'{s.thickness_mm*1000.0:.2f}'
+        result['Absorption length (\u03bCm)'] = 'Requires Density' if not s.absorption_length_um else f'{s.absorption_length_um:.2f}'
         result['Total Mass (mg)'] = f'{s.mass_total_mg:.2f}'
 
         mass_fracs = [f'{el:s}:{mass:.3f}' for el, mass in s.mass_fractions.items()]

--- a/xrayweb/webapp.py
+++ b/xrayweb/webapp.py
@@ -1114,7 +1114,11 @@ def transmission_sample(sample=None, energy=None, absorp_total=None, area=None, 
         energy = float(request.form.get('energy'))
         absorp_total = float(request.form.get('absorp_total'))
         area = float(request.form.get('area'))
-        density = float(request.form.get('density', '1'))
+        density = request.form.get('density', '')
+        if not density:
+            density = None
+        else:
+            density = float(density)
 
         frac_type = request.form.get('frac_type')
         s = xraydb.transmission_sample(sample=sample, energy=energy, absorp_total=absorp_total,
@@ -1122,11 +1126,11 @@ def transmission_sample(sample=None, energy=None, absorp_total=None, area=None, 
 
         result = {}
         result['Energy (eV)'] = f'{s.energy_eV:.2f}'
-        result['Density (gr/cm^3)'] = f'{s.density:.2f}'
+        result['Density (gr/cm^3)'] = 'None' if not density else f'{s.density:.2f}'
         result['Area (cm^2)'] = f'{s.area_cm2:.2f}'
         result['Total Absorption'] = f'{s.absorp_total:.2f}'
-        result['Thickness (\u03bCm)'] = f'{s.thickness_mm*1000.0:.2f}'
-        result['Absorption length (\u03bCm)'] = f'{s.absorption_length_um:.2f}'
+        result['Thickness (\u03bCm)'] = 'None' if not s.thickness_mm else f'{s.thickness_mm*1000.0:.2f}'
+        result['Absorption length (\u03bCm)'] = 'None' if not s.absorption_length_um else f'{s.absorption_length_um:.2f}'
         result['Total Mass (mg)'] = f'{s.mass_total_mg:.2f}'
 
         mass_fracs = [f'{el:s}:{mass:.3f}' for el, mass in s.mass_fractions.items()]


### PR DESCRIPTION
@newville My thought had been to allow the calculation to be done without specifying the density, so that users would not feel like they couldn't get a valid calculation without it. They could run without it, and some of the resultant fields we just be blank. I see now that I didn't quite have it fully handled and it caused some issues with your nicer formatting.

I've made some changes that will fix it. Might not be very 'pythonic' the way I did the one-liners, but let me know what you think.
